### PR TITLE
Fixed the maquette example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ const {div, strong} = hfactory(maquette.h)
 const projector = maquette.createProjector()
 
 const HelloView = (name) => () =>
-    div({className: 'info'},
+    div({class: 'info'},
         strong('Hello ' + name))
 
 projector.append(document.getElementById('app'), HelloView('Maquette!'))


### PR DESCRIPTION
Maquette uses `class` instead of `className`, see https://github.com/AFASSoftware/maquette/blob/master/src/maquette.ts#L451